### PR TITLE
Adds a tile child class to the project page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -17,7 +17,7 @@ permalink: /projects
       {% endfor %}
 
       {% if does_have == 'nop' %}
-        <li class="has-large-top-gap has-text-centered">
+        <li class="tile is-parent has-large-top-gap has-text-centered">
           <h1 class="tile is-child is-size-1 notification">
             No projects to see, yet.
             <i class="has-text-success fa fa-smile-o"></i>


### PR DESCRIPTION
    When no project post is found the message that warns about no post
written should be centered.

Signed-off-by: Rafael Campos Nunes <rafaelnunes@engineer.com>